### PR TITLE
Don't declare `realpath` or pseudo-terminal functions.

### DIFF
--- a/libc-top-half/musl/include/stdlib.h
+++ b/libc-top-half/musl/include/stdlib.h
@@ -126,16 +126,20 @@ int rand_r (unsigned *);
 
 #if defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
  || defined(_BSD_SOURCE)
+#ifdef __wasilibc_unmodified_upstream /* WASI has no absolute paths */
 char *realpath (const char *__restrict, char *__restrict);
+#endif
 long int random (void);
 void srandom (unsigned int);
 char *initstate (unsigned int, char *, size_t);
 char *setstate (char *);
 int putenv (char *);
+#ifdef __wasilibc_unmodified_upstream /* WASI has no pseudo-terminals */
 int posix_openpt (int);
 int grantpt (int);
 int unlockpt (int);
 char *ptsname (int);
+#endif
 char *l64a (long);
 long a64l (const char *);
 void setkey (const char *);


### PR DESCRIPTION
These functions are not currently defined, so suppress their declarations
in the headers.