### PR TITLE
Set the MALLOC_ALIGNMENT to 16?

### DIFF
--- a/dlmalloc/src/dlmalloc.c
+++ b/dlmalloc/src/dlmalloc.c
@@ -29,6 +29,9 @@
 #define NO_MALLINFO 1
 #define NO_MALLOC_STATS 1
 
+/* Align malloc regions to 16, to avoid unaligned SIMD accesses. */
+#define MALLOC_ALIGNMENT 16
+
 /*
  * Declare errno values used by dlmalloc. We define them like this to avoid
  * putting specific errno values in the ABI.


### PR DESCRIPTION
This isn't strictly required, as wasm SIMD loads and stores work on
unaligned memory. However, it may provide better performance. That said,
this isn't currently studied by any benchmarking.

It's not clear what the best approach is here. I'm opening this PR to start a discussion about what the value should be.