### PR TITLE
Fix _DIRENT_HAVE_D_* macros.

### DIFF
--- a/expected/wasm32-wasi/predefined-macros.txt
+++ b/expected/wasm32-wasi/predefined-macros.txt
@@ -2079,8 +2079,6 @@
 #define _CTYPE_H 
 #define _Complex_I (0.0f+1.0fi)
 #define _DIRENT_H 
-#define _DIRENT_HAVE_D_OFF 
-#define _DIRENT_HAVE_D_RECLEN 
 #define _DIRENT_HAVE_D_TYPE 
 #define _ENDIAN_H 
 #define _ERRNO_H 

--- a/libc-bottom-half/headers/public/__struct_dirent.h
+++ b/libc-bottom-half/headers/public/__struct_dirent.h
@@ -3,6 +3,8 @@
 
 #include <__typedef_ino_t.h>
 
+#define _DIRENT_HAVE_D_TYPE
+
 struct dirent {
     ino_t d_ino;
     unsigned char d_type;

--- a/libc-top-half/musl/include/dirent.h
+++ b/libc-top-half/musl/include/dirent.h
@@ -25,11 +25,11 @@ typedef struct __dirstream DIR;
 #include <__typedef_DIR.h>
 #endif
 
+#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 #define _DIRENT_HAVE_D_RECLEN
 #define _DIRENT_HAVE_D_OFF
 #define _DIRENT_HAVE_D_TYPE
 
-#ifdef __wasilibc_unmodified_upstream /* Use alternate WASI libc headers */
 struct dirent {
 	ino_t d_ino;
 	off_t d_off;


### PR DESCRIPTION
Don't define _DIRENT_HAVE_D_RECLEN or _DIRENT_HAVE_D_OFF, as WASI libc's
dirent doesn't have d_reclen or d_off.