### PR TITLE
Don't define readdir64_r.

### DIFF
--- a/expected/wasm32-wasi/predefined-macros.txt
+++ b/expected/wasm32-wasi/predefined-macros.txt
@@ -3400,7 +3400,6 @@
 #define pwrite64 pwrite
 #define pwritev64 pwritev
 #define readdir64 readdir
-#define readdir64_r readdir_r
 #define remainder(x,y) __tg_real_2(remainder, (x), (y))
 #define remquo(x,y,z) __tg_real_remquo((x), (y), (z))
 #define required_argument 1

--- a/libc-top-half/musl/include/dirent.h
+++ b/libc-top-half/musl/include/dirent.h
@@ -85,7 +85,9 @@ int versionsort(const struct dirent **, const struct dirent **);
 #if defined(_LARGEFILE64_SOURCE) || defined(_GNU_SOURCE)
 #define dirent64 dirent
 #define readdir64 readdir
+#ifdef __wasilibc_unmodified_upstream /* readdir_r is obsolete */
 #define readdir64_r readdir_r
+#endif
 #define scandir64 scandir
 #define alphasort64 alphasort
 #define versionsort64 versionsort


### PR DESCRIPTION
wasi-libc doesn't define readdir_r, so don't define readdir64_r as an
alias for it.