### PR TITLE
Remove -fno-builtin.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,8 +188,6 @@ SYSROOT_SHARE = $(SYSROOT)/share/$(MULTIARCH_TRIPLE)
 
 # Set the target.
 override WASM_CFLAGS += --target=$(TARGET_TRIPLE)
-# We're compiling libc.
-override WASM_CFLAGS += -fno-builtin
 # WebAssembly floating-point match doesn't trap.
 # TODO: Add -fno-signaling-nans when the compiler supports it.
 override WASM_CFLAGS += -fno-trapping-math

--- a/dlmalloc/src/dlmalloc.c
+++ b/dlmalloc/src/dlmalloc.c
@@ -41,7 +41,24 @@ extern const int __ENOMEM;
 extern const int __EINVAL;
 #define EINVAL __EINVAL
 
-/* Prefix dlmalloc's names with 'dl'. We wrap them with public names below. */
+/*
+ * Define USE_DL_PREFIX so that we leave dlmalloc's names prefixed with 'dl'.
+ * We define them as "static", and we wrap them with public names below. This
+ * serves two purposes:
+ *
+ * One is to make it easy to control which symbols are exported; dlmalloc
+ * defines several non-standard functions and we wish to explicitly control
+ * which functions are part of our public-facing interface.
+ *
+ * The other is to protect against compilers optimizing based on the assumption
+ * that they know what functions with names like "malloc" do. Code in the
+ * implementation will call functions like "dlmalloc" and assume it can use
+ * the resulting pointers to access the metadata outside of the nominally
+ * allocated objects. However, if the function were named "malloc", compilers
+ * might see code like that and assume it has undefined behavior and can be
+ * optimized away. By using "dlmalloc" in the implementation, we don't need
+ * -fno-builtin to avoid this problem.
+ */
 #define USE_DL_PREFIX 1
 #define DLMALLOC_EXPORT static inline
 


### PR DESCRIPTION
-fno-builtin suppresses optimizations such as turning calls to `sqrt`
or `fabs` into `f64.sqrt` or `f64.abs` instructions inline. Libc code
itself benefits from these optimizations.

I originally added this flag because historically it was needed when
building libc to avoid the compiler pattern-matching the body of memcpy
into a memcpy call, however clang no longer requires this.