### PR TITLE
adjust S_IFIFO to avoid collisions

### DIFF
--- a/expected/wasm32-wasi/predefined-macros.txt
+++ b/expected/wasm32-wasi/predefined-macros.txt
@@ -1717,7 +1717,7 @@
 #define S_IFBLK (0x6000)
 #define S_IFCHR (0x2000)
 #define S_IFDIR (0x4000)
-#define S_IFIFO (0xc000)
+#define S_IFIFO (0x1000)
 #define S_IFLNK (0xa000)
 #define S_IFMT (S_IFBLK | S_IFCHR | S_IFDIR | S_IFIFO | S_IFLNK | S_IFREG | S_IFSOCK)
 #define S_IFREG (0x8000)

--- a/libc-bottom-half/headers/public/__mode_t.h
+++ b/libc-bottom-half/headers/public/__mode_t.h
@@ -9,7 +9,7 @@
 #define S_IFLNK (0xa000)
 #define S_IFREG (0x8000)
 #define S_IFSOCK (0xc000)
-#define S_IFIFO (0xc000)
+#define S_IFIFO (0x1000)
 
 #define S_ISBLK(m) (((m)&S_IFMT) == S_IFBLK)
 #define S_ISCHR(m) (((m)&S_IFMT) == S_IFCHR)


### PR DESCRIPTION
S_IFIFO currently has the same value as S_IFSOCK which breaks code
that does things like "switch (mode & S_IFMT)" as we end up with
duplicate labels.  Move S_IFIFO to a unique unused value.