### PR TITLE
Call `populate_environ` only if we actually need environment variables.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,6 @@ LIBC_TOP_HALF_MUSL_SOURCES = \
     $(LIBC_TOP_HALF_MUSL_SRC_DIR)/fcntl/creat.c \
     $(LIBC_TOP_HALF_MUSL_SRC_DIR)/dirent/alphasort.c \
     $(LIBC_TOP_HALF_MUSL_SRC_DIR)/dirent/versionsort.c \
-    $(LIBC_TOP_HALF_MUSL_SRC_DIR)/env/__environ.c \
     $(LIBC_TOP_HALF_MUSL_SRC_DIR)/env/clearenv.c \
     $(LIBC_TOP_HALF_MUSL_SRC_DIR)/env/getenv.c \
     $(LIBC_TOP_HALF_MUSL_SRC_DIR)/env/putenv.c \
@@ -359,7 +358,7 @@ $(OBJDIR)/%.o: $(CURDIR)/%.c include_dirs
 $(DLMALLOC_OBJS): override WASM_CFLAGS += \
     -I$(DLMALLOC_INC)
 
-$(LIBC_BOTTOM_HALF_ALL_OBJS): override WASM_CFLAGS += \
+startup_files $(LIBC_BOTTOM_HALF_ALL_OBJS): override WASM_CFLAGS += \
     -I$(LIBC_BOTTOM_HALF_HEADERS_PRIVATE) \
     -I$(LIBC_BOTTOM_HALF_CLOUDLIBC_SRC_INC) \
     -I$(LIBC_BOTTOM_HALF_CLOUDLIBC_SRC) \

--- a/expected/wasm32-wasi/defined-symbols.txt
+++ b/expected/wasm32-wasi/defined-symbols.txt
@@ -11,7 +11,6 @@ _IO_putc
 _IO_putc_unlocked
 __EINVAL
 __ENOMEM
-___environ
 __asctime_r
 __assert_fail
 __c_dot_utf8
@@ -252,6 +251,7 @@ __utc
 __wasilibc_fd_renumber
 __wasilibc_find_relpath
 __wasilibc_init_preopen
+__wasilibc_populate_environ
 __wasilibc_register_preopened_fd
 __wasilibc_rmdirat
 __wasilibc_tell

--- a/libc-bottom-half/headers/private/wasi/libc-internal.h
+++ b/libc-bottom-half/headers/private/wasi/libc-internal.h
@@ -1,0 +1,17 @@
+#ifndef __wasi_libc_internal_h
+#define __wasi_libc_internal_h
+
+#include <wasi/core.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void __wasilibc_init_preopen(void);
+__wasi_errno_t __wasilibc_populate_environ(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libc-bottom-half/headers/public/wasi/libc.h
+++ b/libc-bottom-half/headers/public/wasi/libc.h
@@ -7,7 +7,6 @@
 extern "C" {
 #endif
 
-void __wasilibc_init_preopen(void);
 int __wasilibc_register_preopened_fd(int fd, const char *path);
 int __wasilibc_fd_renumber(int fd, int newfd);
 int __wasilibc_unlinkat(int fd, const char *path);

--- a/libc-bottom-half/sources/__environ.c
+++ b/libc-bottom-half/sources/__environ.c
@@ -21,12 +21,15 @@ __wasi_errno_t __wasilibc_populate_environ(void) {
         return err;
     }
 
-    // Allocate memory for the array of pointers, adding null terminator.
-    __environ = malloc(sizeof(char *) * (environ_count + 1));
-
     // Allocate memory for storing the environment chars.
     char *environ_buf = malloc(sizeof(char) * environ_buf_size);
-    if (__environ == NULL || environ_buf == NULL) {
+    if (environ_buf == NULL) {
+        return __WASI_ENOMEM;
+    }
+
+    // Allocate memory for the array of pointers, adding null terminator.
+    __environ = malloc(sizeof(char *) * (environ_count + 1));
+    if (__environ == NULL) {
         return __WASI_ENOMEM;
     }
 

--- a/libc-bottom-half/sources/__environ.c
+++ b/libc-bottom-half/sources/__environ.c
@@ -40,6 +40,9 @@ __wasi_errno_t __wasilibc_populate_environ(void) {
     err = __wasi_environ_get(environ_ptrs, environ_buf);
     if (err == __WASI_ESUCCESS) {
         __environ = environ_ptrs;
+    } else {
+        free(environ_buf);
+        free(environ_ptrs);
     }
     return err;
 }

--- a/libc-bottom-half/sources/__environ.c
+++ b/libc-bottom-half/sources/__environ.c
@@ -21,16 +21,21 @@ __wasi_errno_t __wasilibc_populate_environ(void) {
         return err;
     }
 
+    // Add 1 for the NULL pointer to mark the end, and check for overflow.
+    size_t num_ptrs = environ_count + 1;
+    if (num_ptrs == 0) {
+        return __WASI_ENOMEM;
+    }
+
     // Allocate memory for storing the environment chars.
     char *environ_buf = malloc(environ_buf_size);
     if (environ_buf == NULL) {
         return __WASI_ENOMEM;
     }
 
-    // Allocate memory for the array of pointers. Note the `+ 1` to include
-    // space for a NULL pointer at the end. This uses `calloc` both to handle
-    // overflow and to initialize the NULL pointer at the end.
-    char **environ_ptrs = calloc(environ_count + 1, sizeof(char *));
+    // Allocate memory for the array of pointers. This uses `calloc` both to
+    // handle overflow and to initialize the NULL pointer at the end.
+    char **environ_ptrs = calloc(num_ptrs, sizeof(char *));
     if (environ_ptrs == NULL) {
         free(environ_buf);
         return __WASI_ENOMEM;

--- a/libc-bottom-half/sources/__environ.c
+++ b/libc-bottom-half/sources/__environ.c
@@ -30,6 +30,7 @@ __wasi_errno_t __wasilibc_populate_environ(void) {
     // Allocate memory for the array of pointers, adding null terminator.
     __environ = malloc(sizeof(char *) * (environ_count + 1));
     if (__environ == NULL) {
+        free(environ_buf);
         return __WASI_ENOMEM;
     }
 

--- a/libc-bottom-half/sources/__environ.c
+++ b/libc-bottom-half/sources/__environ.c
@@ -1,0 +1,37 @@
+#include <unistd.h>
+#include <wasi/core.h>
+#include <wasi/libc.h>
+#include <wasi/libc-internal.h>
+
+char **__environ = NULL;
+extern __typeof(__environ) _environ __attribute__((weak, alias("__environ")));
+extern __typeof(__environ) environ __attribute__((weak, alias("__environ")));
+
+// This function is referenced by a weak symbol in crt1.c, and we define
+// it here in the same source file as __environ, so that this function is
+// linked in iff environment variable support is used.
+__wasi_errno_t __wasilibc_populate_environ(void) {
+    __wasi_errno_t err;
+
+    /* Get the sizes of the arrays we'll have to create to copy in the environment. */
+    size_t environ_count;
+    size_t environ_buf_size;
+    err = __wasi_environ_sizes_get(&environ_count, &environ_buf_size);
+    if (err != __WASI_ESUCCESS) {
+        return err;
+    }
+
+    /* Allocate memory for the array of pointers, adding null terminator. */
+    __environ = malloc(sizeof(char *) * (environ_count + 1));
+    /* Allocate memory for storing the environment chars. */
+    char *environ_buf = malloc(sizeof(char) * environ_buf_size);
+    if (__environ == NULL || environ_buf == NULL) {
+        return __WASI_ENOMEM;
+    }
+
+    /* Make sure the last pointer in the array is NULL. */
+    __environ[environ_count] = NULL;
+
+    /* Fill the environment chars, and the __environ array with pointers into those chars. */
+    return __wasi_environ_get(__environ, environ_buf);
+}

--- a/libc-bottom-half/sources/__environ.c
+++ b/libc-bottom-half/sources/__environ.c
@@ -21,6 +21,9 @@ __wasi_errno_t __wasilibc_populate_environ(void) {
     if (err != __WASI_ESUCCESS) {
         return err;
     }
+    if (environ_count == 0) {
+        return __WASI_ESUCCESS;
+    }
 
     // Add 1 for the NULL pointer to mark the end, and check for overflow.
     size_t num_ptrs = environ_count + 1;

--- a/libc-bottom-half/sources/__environ.c
+++ b/libc-bottom-half/sources/__environ.c
@@ -1,4 +1,5 @@
 #include <unistd.h>
+#include <stdlib.h>
 #include <wasi/core.h>
 #include <wasi/libc.h>
 #include <wasi/libc-internal.h>

--- a/libc-bottom-half/sources/__environ.c
+++ b/libc-bottom-half/sources/__environ.c
@@ -22,20 +22,19 @@ __wasi_errno_t __wasilibc_populate_environ(void) {
     }
 
     // Allocate memory for storing the environment chars.
-    char *environ_buf = malloc(sizeof(char) * environ_buf_size);
+    char *environ_buf = malloc(environ_buf_size);
     if (environ_buf == NULL) {
         return __WASI_ENOMEM;
     }
 
-    // Allocate memory for the array of pointers, adding null terminator.
-    __environ = malloc(sizeof(char *) * (environ_count + 1));
+    // Allocate memory for the array of pointers. Note the `+ 1` to include
+    // space for a NULL pointer at the end. This uses `calloc` both to handle
+    // overflow and to initialize the NULL pointer at the end.
+    __environ = calloc(environ_count + 1, sizeof(char *));
     if (__environ == NULL) {
         free(environ_buf);
         return __WASI_ENOMEM;
     }
-
-    // Make sure the last pointer in the array is NULL.
-    __environ[environ_count] = NULL;
 
     // Fill the environment chars, and the __environ array with pointers into those chars.
     return __wasi_environ_get(__environ, environ_buf);

--- a/libc-bottom-half/sources/__environ.c
+++ b/libc-bottom-half/sources/__environ.c
@@ -30,12 +30,16 @@ __wasi_errno_t __wasilibc_populate_environ(void) {
     // Allocate memory for the array of pointers. Note the `+ 1` to include
     // space for a NULL pointer at the end. This uses `calloc` both to handle
     // overflow and to initialize the NULL pointer at the end.
-    __environ = calloc(environ_count + 1, sizeof(char *));
-    if (__environ == NULL) {
+    char **environ_ptrs = calloc(environ_count + 1, sizeof(char *));
+    if (environ_ptrs == NULL) {
         free(environ_buf);
         return __WASI_ENOMEM;
     }
 
     // Fill the environment chars, and the __environ array with pointers into those chars.
-    return __wasi_environ_get(__environ, environ_buf);
+    err = __wasi_environ_get(environ_ptrs, environ_buf);
+    if (err == __WASI_ESUCCESS) {
+        __environ = environ_ptrs;
+    }
+    return err;
 }

--- a/libc-bottom-half/sources/__environ.c
+++ b/libc-bottom-half/sources/__environ.c
@@ -13,7 +13,7 @@ extern __typeof(__environ) environ __attribute__((weak, alias("__environ")));
 __wasi_errno_t __wasilibc_populate_environ(void) {
     __wasi_errno_t err;
 
-    /* Get the sizes of the arrays we'll have to create to copy in the environment. */
+    // Get the sizes of the arrays we'll have to create to copy in the environment.
     size_t environ_count;
     size_t environ_buf_size;
     err = __wasi_environ_sizes_get(&environ_count, &environ_buf_size);
@@ -21,17 +21,18 @@ __wasi_errno_t __wasilibc_populate_environ(void) {
         return err;
     }
 
-    /* Allocate memory for the array of pointers, adding null terminator. */
+    // Allocate memory for the array of pointers, adding null terminator.
     __environ = malloc(sizeof(char *) * (environ_count + 1));
-    /* Allocate memory for storing the environment chars. */
+
+    // Allocate memory for storing the environment chars.
     char *environ_buf = malloc(sizeof(char) * environ_buf_size);
     if (__environ == NULL || environ_buf == NULL) {
         return __WASI_ENOMEM;
     }
 
-    /* Make sure the last pointer in the array is NULL. */
+    // Make sure the last pointer in the array is NULL.
     __environ[environ_count] = NULL;
 
-    /* Fill the environment chars, and the __environ array with pointers into those chars. */
+    // Fill the environment chars, and the __environ array with pointers into those chars.
     return __wasi_environ_get(__environ, environ_buf);
 }


### PR DESCRIPTION
This avoids a couple of mallocs and calls to __wasi_environ_sizes_get
and __wasi_environ_get in programs that don't use environment variables.

In theory this should work, however it doesn't currently work as
intended, and seems to be blocked by [LLVM PR43696].

[LLVM PR43696]: https://bugs.llvm.org/show_bug.cgi?id=43696