### PR TITLE
Make sbrk(0) deterministic

### DIFF
--- a/libc-bottom-half/sources/sbrk.c
+++ b/libc-bottom-half/sources/sbrk.c
@@ -6,7 +6,8 @@
 /* Bare-bones implementation of sbrk. */
 void *sbrk(intptr_t increment) {
     /* sbrk(0) returns the current memory size. */
-    if(increment == 0) {
+    if (increment == 0) {
+        /* The wasm spec doesn't guarantee that memory.grow of 0 always succeeds. */
         return (void *)(__builtin_wasm_memory_size(0) * PAGESIZE);
     }
 

--- a/libc-bottom-half/sources/sbrk.c
+++ b/libc-bottom-half/sources/sbrk.c
@@ -3,8 +3,13 @@
 #include <errno.h>
 #include <__macro_PAGESIZE.h>
 
-/* Bare-bones implementation of sbrk: just call memory.grow. */
+/* Bare-bones implementation of sbrk. */
 void *sbrk(intptr_t increment) {
+    /* sbrk(0) returns the current memory size. */
+    if(increment == 0) {
+        return (void *)(__builtin_wasm_memory_size(0) * PAGESIZE);
+    }
+
     /* We only support page-size increments. */
     if (increment % PAGESIZE != 0) {
         abort();


### PR DESCRIPTION
The Wasm spec doesn't specify explicitly the behaviour of `memory.grow 0`. And because of
```
The memory.grow instruction is non-deterministic. It may either succeed, returning the old memory size
sz , or fail, returning −1. Failure must occur if the referenced memory instance has a maximum size defined that
would be exceeded. However, failure can occur in other cases as well. In practice, the choice depends on the
resources available to the embedder.
```
`memory.grow 0` could potentially be  non-deterministic. From the other side, WASI dlmalloc heavily relies on it. So, it seems that it is better to make sbrk(0) deterministic.

Also `memory.size` is much faster on many execution environments, since memory could shared and some code with locking could be called (like in [v8](https://github.com/v8/v8/blob/4b9b23521e6fd42373ebbcb20ebe03bf445494f9/src/wasm/wasm-objects.cc#L1240)).