### PR TITLE
Workaround a bug causing Windows CI failures.

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -43,7 +43,9 @@ jobs:
         # wasi-libc. Rust's llvm-tools include llvm-nm, and Rust is installed on Azure's Windows
         # images, so we can use that to make llvm-nm available without too much overhead.
         set -euo pipefail
-        rustup update stable
+        # Add --no-self-update as a workaround for
+        # https://github.com/microsoft/azure-pipelines-image-generation/issues/1224
+        rustup update stable --no-self-update
         rustup default stable
         rustup component add llvm-tools-preview
         echo "##vso[task.setvariable variable=WASM_NM;]$(rustc --print sysroot|sed 's|C:|/c|'|sed 's|\\|/|g')/lib/rustlib/x86_64-pc-windows-msvc/bin/llvm-nm.exe"


### PR DESCRIPTION
This works around [this bug], which manifests as

```
error: could not remove 'setup' file: 'C:\Users\VssAdministrator\.cargo\bin/rustup-init.exe'
info: caused by: Access is denied. (os error 5)
```

as suggested by [this comment].

[this bug]: https://github.com/microsoft/azure-pipelines-image-generation/issues/1224
[this comment]: https://github.com/CraneStation/wasi-libc/pull/118#issuecomment-544978683