### PR TITLE
Optimize `fmin`, `fmax`, etc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,9 @@ LIBC_TOP_HALF_MUSL_SOURCES = \
                  %/nearbyintf.c %/nearbyint.c \
                  %/sqrtf.c %/sqrt.c \
                  %/fabsf.c %/fabs.c \
-                 %/copysignf.c %/copysign.c, \
+                 %/copysignf.c %/copysign.c \
+                 %/fminf.c %/fmaxf.c \
+                 %/fmin.c %/fmax.c, \
                  $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/math/*.c)) \
     $(filter-out %/crealf.c %/creal.c \
                  %/cimagf.c %/cimag.c, \

--- a/basics/sources/fmin-fmax.c
+++ b/basics/sources/fmin-fmax.c
@@ -1,0 +1,34 @@
+// Wasm's `min` and `max` operators implement the IEEE 754-2019
+// `minimum` and `maximum` operations, meaning that given a choice
+// between NaN and a number, they return NaN. This differs from
+// the C standard library's `fmin` and `fmax` functions, which
+// return the number. However, we can still use wasm's builtins
+// by handling the NaN cases explicitly, and it still turns out
+// to be faster than doing the whole operation in
+// target-independent C. And, it's smaller.
+
+#include <math.h>
+
+float fminf(float x, float y) {
+    if (isnan(x)) return y;
+    if (isnan(y)) return x;
+    return __builtin_wasm_min_f32(x, y);
+}
+
+float fmaxf(float x, float y) {
+    if (isnan(x)) return y;
+    if (isnan(y)) return x;
+    return __builtin_wasm_max_f32(x, y);
+}
+
+double fmin(double x, double y) {
+    if (isnan(x)) return y;
+    if (isnan(y)) return x;
+    return __builtin_wasm_min_f64(x, y);
+}
+
+double fmax(double x, double y) {
+    if (isnan(x)) return y;
+    if (isnan(y)) return x;
+    return __builtin_wasm_max_f64(x, y);
+}


### PR DESCRIPTION
Use wasm's builtin min and max operators to implement libc `fmin`,
`fmax, `fminf`, and `fmaxf`, by handling the NaN cases explicitly.

Credit to https://github.com/emscripten-core/emscripten/pull/9689
for spotting this opportunity!