### PR TITLE
Don't build bind_textdomain_codeset.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ LIBC_TOP_HALF_MUSL_SOURCES = \
                  $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/stdio/*.c)) \
     $(filter-out %/strsignal.c, \
                  $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/string/*.c)) \
-    $(filter-out %/dcngettext.c %/textdomain.c, \
+    $(filter-out %/dcngettext.c %/textdomain.c %/bind_textdomain_codeset.c, \
                  $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/locale/*.c)) \
     $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/stdlib/*.c) \
     $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/search/*.c) \

--- a/expected/wasm32-wasi/defined-symbols.txt
+++ b/expected/wasm32-wasi/defined-symbols.txt
@@ -313,7 +313,6 @@ atoll
 basename
 bcmp
 bcopy
-bind_textdomain_codeset
 bsearch
 btowc
 bzero


### PR DESCRIPTION
`bind_textdomain_codeset` without the rest of libintl.h isn't useful
without the rest of gettext.