### PR TITLE
Avoid using user identifiers in function declarations.

### DIFF
--- a/basics/include/__functions_malloc.h
+++ b/basics/include/__functions_malloc.h
@@ -10,13 +10,13 @@
 extern "C" {
 #endif
 
-void *malloc(size_t size) __attribute__((__malloc__, __warn_unused_result__));
-void free(void *ptr);
-void *calloc(size_t nmemb, size_t size) __attribute__((__malloc__, __warn_unused_result__));
-void *realloc(void *ptr, size_t size) __attribute__((__warn_unused_result__));
+void *malloc(size_t __size) __attribute__((__malloc__, __warn_unused_result__));
+void free(void *__ptr);
+void *calloc(size_t __nmemb, size_t __size) __attribute__((__malloc__, __warn_unused_result__));
+void *realloc(void *__ptr, size_t __size) __attribute__((__warn_unused_result__));
 
 #if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
-void *reallocarray(void *, size_t, size_t) __attribute__((__warn_unused_result__));
+void *reallocarray(void *__ptr, size_t __nmemb, size_t __size) __attribute__((__warn_unused_result__));
 #endif
 
 #ifdef __cplusplus

--- a/basics/include/__functions_memcpy.h
+++ b/basics/include/__functions_memcpy.h
@@ -9,9 +9,9 @@
 extern "C" {
 #endif
 
-void *memcpy(void *__restrict__ dst, const void *__restrict__ src, size_t n) __attribute__((__nothrow__, __leaf__, __nonnull__(1, 2)));
-void *memmove(void *dst, const void *src, size_t n) __attribute__((__nothrow__, __leaf__, __nonnull__(1, 2)));
-void *memset(void *dst, int c, size_t n) __attribute__((__nothrow__, __leaf__, __nonnull__(1)));
+void *memcpy(void *__restrict__ __dst, const void *__restrict__ __src, size_t __n) __attribute__((__nothrow__, __leaf__, __nonnull__(1, 2)));
+void *memmove(void *__dst, const void *__src, size_t __n) __attribute__((__nothrow__, __leaf__, __nonnull__(1, 2)));
+void *memset(void *__dst, int __c, size_t __n) __attribute__((__nothrow__, __leaf__, __nonnull__(1)));
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
MultiSource/Benchmarks/McCat in llvm-test-suite has a macro named
`n`, so rename function parameters to avoid colliding.