### PR TITLE
Ensure `__environ` is initialized even when it's empty.

### DIFF
--- a/libc-bottom-half/sources/__environ.c
+++ b/libc-bottom-half/sources/__environ.c
@@ -4,7 +4,8 @@
 #include <wasi/libc.h>
 #include <wasi/libc-internal.h>
 
-char **__environ = NULL;
+static char *empty_environ[1] = { NULL };
+char **__environ = empty_environ;
 extern __typeof(__environ) _environ __attribute__((weak, alias("__environ")));
 extern __typeof(__environ) environ __attribute__((weak, alias("__environ")));
 


### PR DESCRIPTION
POSIX requires `environ` to be a pointer to a NULL-terminated array of
pointers, so it itself can't be NULL.

This fixes a regression in src/functional/env.c in wasi-libc-test.