### PR TITLE
Use consistent style for wasi-libc C source files.

### DIFF
--- a/basics/crt/crt1.c
+++ b/basics/crt/crt1.c
@@ -1,19 +1,22 @@
 extern void __wasm_call_ctors(void);
-extern int main(int, char *[]);
+extern int __original_main(void);
 extern void __prepare_for_exit(void);
 void _Exit(int) __attribute__((noreturn));
 
 void _start(void) {
-    /* The linker synthesizes this to call constructors. */
+    // The linker synthesizes this to call constructors.
     __wasm_call_ctors();
 
-    /* Call main with no arguments. */
-    int r = main(0, 0);
+    // Call `__original_main` which will either be the application's
+    // zero-argument `main` function (renamed by the compiler) or a libc
+    // routine which populates `argv` and `argc` and calls the application's
+    // two-argument `main`.
+    int r = __original_main();
 
-    /* Call atexit functions, destructors, stdio cleanup, etc. */
+    // Call atexit functions, destructors, stdio cleanup, etc.
     __prepare_for_exit();
 
-    /* If main exited successfully, just return, otherwise call _Exit. */
+    // If main exited successfully, just return, otherwise call _Exit.
     if (r != 0) {
         _Exit(r);
     }

--- a/libc-bottom-half/mman/mman.c
+++ b/libc-bottom-half/mman/mman.c
@@ -1,10 +1,8 @@
-/*
- * Userspace emulation of mmap and munmap. Restrictions apply.
- *
- * This is meant to be complete enough to be compatible with code that uses
- * mmap for simple file I/O. It just allocates memory with malloc and reads
- * and writes data with pread and pwrite.
- */
+// Userspace emulation of mmap and munmap. Restrictions apply.
+//
+// This is meant to be complete enough to be compatible with code that uses
+// mmap for simple file I/O. It just allocates memory with malloc and reads
+// and writes data with pread and pwrite.
 
 #define _WASI_EMULATED_MMAN
 #include <stdlib.h>
@@ -110,7 +108,7 @@ void *mmap(void *addr, size_t length, int prot, int flags,
 
 int munmap(void *addr, size_t length) {
     struct map *map = (struct map *)addr - 1;
-    
+
     // We don't support partial munmapping.
     if (map->length != length) {
         errno = EINVAL;

--- a/libc-bottom-half/sources/errno.c
+++ b/libc-bottom-half/sources/errno.c
@@ -1,6 +1,6 @@
 #include <errno.h>
 #include <threads.h>
 
-/* These values are used by reference-sysroot's dlmalloc. */
+// These values are used by reference-sysroot's dlmalloc.
 const int __EINVAL = EINVAL;
 const int __ENOMEM = ENOMEM;

--- a/libc-bottom-half/sources/sbrk.c
+++ b/libc-bottom-half/sources/sbrk.c
@@ -3,26 +3,26 @@
 #include <errno.h>
 #include <__macro_PAGESIZE.h>
 
-/* Bare-bones implementation of sbrk. */
+// Bare-bones implementation of sbrk.
 void *sbrk(intptr_t increment) {
-    /* sbrk(0) returns the current memory size. */
+    // sbrk(0) returns the current memory size.
     if (increment == 0) {
-        /* The wasm spec doesn't guarantee that memory.grow of 0 always succeeds. */
+        // The wasm spec doesn't guarantee that memory.grow of 0 always succeeds.
         return (void *)(__builtin_wasm_memory_size(0) * PAGESIZE);
     }
 
-    /* We only support page-size increments. */
+    // We only support page-size increments.
     if (increment % PAGESIZE != 0) {
         abort();
     }
 
-    /* WebAssembly doesn't support shrinking linear memory. */
+    // WebAssembly doesn't support shrinking linear memory.
     if (increment < 0) {
         abort();
     }
 
     uintptr_t old = __builtin_wasm_memory_grow(0, (uintptr_t)increment / PAGESIZE);
-   
+
     if (old == SIZE_MAX) {
         errno = ENOMEM;
         return (void *)-1;

--- a/libc-top-half/headers/private/printscan.h
+++ b/libc-top-half/headers/private/printscan.h
@@ -53,7 +53,7 @@ static void long_double_not_supported(void) {
 
 #else
 
-/* Full long double support. */
+// Full long double support.
 typedef long double long_double;
 
 #endif

--- a/libc-top-half/sources/arc4random.c
+++ b/libc-top-half/sources/arc4random.c
@@ -12,148 +12,149 @@
 #define ROTL32(x, b) (uint32_t)(((x) << (b)) | ((x) >> (32 - (b))))
 
 #define CHACHA20_QUARTERROUND(A, B, C, D) \
-	A += B;                               \
-	D = ROTL32(D ^ A, 16);                \
-	C += D;                               \
-	B = ROTL32(B ^ C, 12);                \
-	A += B;                               \
-	D = ROTL32(D ^ A, 8);                 \
-	C += D;                               \
-	B = ROTL32(B ^ C, 7)
+    A += B;                               \
+    D = ROTL32(D ^ A, 16);                \
+    C += D;                               \
+    B = ROTL32(B ^ C, 12);                \
+    A += B;                               \
+    D = ROTL32(D ^ A, 8);                 \
+    C += D;                               \
+    B = ROTL32(B ^ C, 7)
 
 static void CHACHA20_ROUNDS(uint32_t st[16])
 {
-	int i;
+    int i;
 
-	for (i = 0; i < 20; i += 2) {
-		CHACHA20_QUARTERROUND(st[0], st[4], st[8], st[12]);
-		CHACHA20_QUARTERROUND(st[1], st[5], st[9], st[13]);
-		CHACHA20_QUARTERROUND(st[2], st[6], st[10], st[14]);
-		CHACHA20_QUARTERROUND(st[3], st[7], st[11], st[15]);
-		CHACHA20_QUARTERROUND(st[0], st[5], st[10], st[15]);
-		CHACHA20_QUARTERROUND(st[1], st[6], st[11], st[12]);
-		CHACHA20_QUARTERROUND(st[2], st[7], st[8], st[13]);
-		CHACHA20_QUARTERROUND(st[3], st[4], st[9], st[14]);
-	}
+    for (i = 0; i < 20; i += 2) {
+        CHACHA20_QUARTERROUND(st[0], st[4], st[8], st[12]);
+        CHACHA20_QUARTERROUND(st[1], st[5], st[9], st[13]);
+        CHACHA20_QUARTERROUND(st[2], st[6], st[10], st[14]);
+        CHACHA20_QUARTERROUND(st[3], st[7], st[11], st[15]);
+        CHACHA20_QUARTERROUND(st[0], st[5], st[10], st[15]);
+        CHACHA20_QUARTERROUND(st[1], st[6], st[11], st[12]);
+        CHACHA20_QUARTERROUND(st[2], st[7], st[8], st[13]);
+        CHACHA20_QUARTERROUND(st[3], st[4], st[9], st[14]);
+    }
 }
 
 static void chacha20_update(uint8_t out[CHACHA20_BLOCKBYTES], uint32_t st[16])
 {
-	uint32_t ks[16];
-	int i;
+    uint32_t ks[16];
+    int i;
 
-	memcpy(ks, st, 4 * 16);
-	CHACHA20_ROUNDS(st);
-	for (i = 0; i < 16; i++) {
-		ks[i] += st[i];
-	}
-	memcpy(out, ks, CHACHA20_BLOCKBYTES);
-	st[12]++;
+    memcpy(ks, st, 4 * 16);
+    CHACHA20_ROUNDS(st);
+    for (i = 0; i < 16; i++) {
+        ks[i] += st[i];
+    }
+    memcpy(out, ks, CHACHA20_BLOCKBYTES);
+    st[12]++;
 }
 
 static void chacha20_init(uint32_t st[16], const uint8_t key[CHACHA20_KEYBYTES])
 {
-	static const uint32_t constants[4] = { 0x61707865, 0x3320646e, 0x79622d32, 0x6b206574 };
-	memcpy(&st[0], constants, 4 * 4);
-	memcpy(&st[4], key, CHACHA20_KEYBYTES);
-	memset(&st[12], 0, 4 * 4);
+    static const uint32_t constants[4] = { 0x61707865, 0x3320646e, 0x79622d32, 0x6b206574 };
+    memcpy(&st[0], constants, 4 * 4);
+    memcpy(&st[4], key, CHACHA20_KEYBYTES);
+    memset(&st[12], 0, 4 * 4);
 }
 
 static int chacha20_rng(uint8_t* out, size_t len, uint8_t key[CHACHA20_KEYBYTES])
 {
-	uint32_t st[16];
-	size_t off;
+    uint32_t st[16];
+    size_t off;
 
-	chacha20_init(st, key);
-	chacha20_update(&out[0], st);
-	memcpy(key, out, CHACHA20_KEYBYTES);
-	off = 0;
-	while (len >= CHACHA20_BLOCKBYTES) {
-		chacha20_update(&out[off], st);
-		len -= CHACHA20_BLOCKBYTES;
-		off += CHACHA20_BLOCKBYTES;
-	}
-	if (len > 0) {
-		uint8_t tmp[CHACHA20_BLOCKBYTES];
-		chacha20_update(tmp, st);
-		memcpy(&out[off], tmp, len);
-	}
-	return 0;
+    chacha20_init(st, key);
+    chacha20_update(&out[0], st);
+    memcpy(key, out, CHACHA20_KEYBYTES);
+    off = 0;
+    while (len >= CHACHA20_BLOCKBYTES) {
+        chacha20_update(&out[off], st);
+        len -= CHACHA20_BLOCKBYTES;
+        off += CHACHA20_BLOCKBYTES;
+    }
+    if (len > 0) {
+        uint8_t tmp[CHACHA20_BLOCKBYTES];
+        chacha20_update(tmp, st);
+        memcpy(&out[off], tmp, len);
+    }
+    return 0;
 }
 
 struct rng_state {
-	int initialized;
-	size_t off;
-	uint8_t key[CHACHA20_KEYBYTES];
-	uint8_t reserve[RNG_RESERVE_LEN];
+    int initialized;
+    size_t off;
+    uint8_t key[CHACHA20_KEYBYTES];
+    uint8_t reserve[RNG_RESERVE_LEN];
 };
 
 void arc4random_buf(void* buffer, size_t len)
 {
-	static _Thread_local struct rng_state rng_state;
+    static _Thread_local struct rng_state rng_state;
 
-	unsigned char* buffer_ = (unsigned char*)buffer;
-	size_t off;
-	size_t remaining;
-	size_t partial;
+    unsigned char* buffer_ = (unsigned char*)buffer;
+    size_t off;
+    size_t remaining;
+    size_t partial;
 
-	if (!rng_state.initialized) {
-		if (getentropy(rng_state.key, sizeof rng_state.key) != 0) {
-			assert(0);
-		}
-		rng_state.off = RNG_RESERVE_LEN;
-		rng_state.initialized = 1;
-	}
-	off = 0;
-	remaining = len;
-	while (remaining > 0) {
-		if (rng_state.off == RNG_RESERVE_LEN) {
-			while (remaining >= RNG_RESERVE_LEN) {
-				chacha20_rng(&buffer_[off], RNG_RESERVE_LEN, rng_state.key);
-				off += RNG_RESERVE_LEN;
-				remaining -= RNG_RESERVE_LEN;
-			}
-			if (remaining == 0) {
-				break;
-			}
-			chacha20_rng(&rng_state.reserve[0], RNG_RESERVE_LEN, rng_state.key);
-			rng_state.off = 0;
-		}
-		partial = RNG_RESERVE_LEN - rng_state.off;
-		if (remaining < partial) {
-			partial = remaining;
-		}
-		memcpy(&buffer_[off], &rng_state.reserve[rng_state.off], partial);
-		memset(&rng_state.reserve[rng_state.off], 0, partial);
-		rng_state.off += partial;
-		remaining -= partial;
-		off += partial;
-	}
+    if (!rng_state.initialized) {
+        if (getentropy(rng_state.key, sizeof rng_state.key) != 0) {
+            assert(0);
+        }
+        rng_state.off = RNG_RESERVE_LEN;
+        rng_state.initialized = 1;
+    }
+    off = 0;
+    remaining = len;
+    while (remaining > 0) {
+        if (rng_state.off == RNG_RESERVE_LEN) {
+            while (remaining >= RNG_RESERVE_LEN) {
+                chacha20_rng(&buffer_[off], RNG_RESERVE_LEN, rng_state.key);
+                off += RNG_RESERVE_LEN;
+                remaining -= RNG_RESERVE_LEN;
+            }
+            if (remaining == 0) {
+                break;
+            }
+            chacha20_rng(&rng_state.reserve[0], RNG_RESERVE_LEN, rng_state.key);
+            rng_state.off = 0;
+        }
+        partial = RNG_RESERVE_LEN - rng_state.off;
+        if (remaining < partial) {
+            partial = remaining;
+        }
+        memcpy(&buffer_[off], &rng_state.reserve[rng_state.off], partial);
+        memset(&rng_state.reserve[rng_state.off], 0, partial);
+        rng_state.off += partial;
+        remaining -= partial;
+        off += partial;
+    }
 }
 
 uint32_t arc4random(void)
 {
-	uint32_t v;
+    uint32_t v;
 
-	arc4random_buf(&v, sizeof v);
+    arc4random_buf(&v, sizeof v);
 
-	return v;
+    return v;
 }
 
 uint32_t arc4random_uniform(const uint32_t upper_bound)
 {
-	uint32_t min;
-	uint32_t r;
+    uint32_t min;
+    uint32_t r;
 
-	if (upper_bound < 2U) {
-		return 0;
-	}
-	min = (1U + ~upper_bound) % upper_bound; /* = 2**32 mod upper_bound */
-	do {
-		r = arc4random();
-	} while (r < min);
-	/* r is now clamped to a set whose size mod upper_bound == 0
-     * the worst case (2**31+1) requires 2 attempts on average */
+    if (upper_bound < 2U) {
+        return 0;
+    }
+    min = (1U + ~upper_bound) % upper_bound; // = 2**32 mod upper_bound
+    do {
+        r = arc4random();
+    } while (r < min);
 
-	return r % upper_bound;
+    // r is now clamped to a set whose size mod upper_bound == 0.
+    // The worst case (2**31+1) requires 2 attempts on average.
+
+    return r % upper_bound;
 }


### PR DESCRIPTION
For now, this means using `//`-style comments in .c source files (though
not public header files), and spaces rather than tabs. No strong opinion
here; this is just what the majority of the current code is using.

This also synchronizes basics/crt/crt1.c with libc-bottom-half's
version, though this is just a cleanup as the former isn't currently used
by the main wasi-libc build.

cc @michaelvoronov This follows up on https://github.com/CraneStation/wasi-libc/issues/116. It isn't a guide per se, but it does make things more consistent.