### PR TITLE
Temporarily disable the use of `__heap_base`.

### DIFF
--- a/dlmalloc/src/malloc.c
+++ b/dlmalloc/src/malloc.c
@@ -4560,9 +4560,11 @@ static void* tmalloc_small(mstate m, size_t nb) {
 
 #if !ONLY_MSPACES
 
+#if 0 // Temporarily work around https://bugs.llvm.org/show_bug.cgi?id=43613
 #if __wasilibc_unmodified_upstream // Forward declaration of try_init_allocator.
 #else
 static void try_init_allocator(void);
+#endif
 #endif
 
 void* dlmalloc(size_t bytes) {
@@ -4593,11 +4595,13 @@ void* dlmalloc(size_t bytes) {
   ensure_initialization(); /* initialize in sys_alloc if not using locks */
 #endif
 
+#if 0 // Temporarily work around https://bugs.llvm.org/show_bug.cgi?id=43613
 #if __wasilibc_unmodified_upstream // Try to initialize the allocator.
 #else
   if (!is_initialized(gm)) {
     try_init_allocator();
   }
+#endif
 #endif
 
   if (!PREACTION(gm)) {
@@ -5209,6 +5213,7 @@ static void internal_inspect_all(mstate m,
 }
 #endif /* MALLOC_INSPECT_ALL */
 
+#if 0 // Temporarily work around https://bugs.llvm.org/show_bug.cgi?id=43613
 #ifdef __wasilibc_unmodified_upstream // Define a function that initializes the initial state of dlmalloc
 #else
 /* ------------------ Exported try_init_allocator -------------------- */
@@ -5243,6 +5248,7 @@ static void try_init_allocator(void) {
   init_bins(gm);
   init_top(gm, (mchunkptr)base, initial_heap_size - TOP_FOOT_SIZE);
 }
+#endif
 #endif
 
 /* ------------------ Exported realloc, memalign, etc -------------------- */

--- a/expected/wasm32-wasi/undefined-symbols.txt
+++ b/expected/wasm32-wasi/undefined-symbols.txt
@@ -10,7 +10,6 @@ __floatsitf
 __floatunsitf
 __getf2
 __gttf2
-__heap_base
 __letf2
 __lttf2
 __netf2


### PR DESCRIPTION
#114, which we just merged, unfortunately hits an LLVM bug, which is fixed on LLVM master, but not yet in LLVM 9.0. Disable the feature for now to unbreak the tree with LLVM 9.0.

This temporarily disables the feature in
a214f1c0b167608ab4ec3e63f8144c3430af9372, since it hits LLVM bug
43613, which is fixed on LLVM master and awaiting a backport to
the 9.0 branch.

https://bugs.llvm.org/show_bug.cgi?id=43613