### PR TITLE
Make the `__original_main` definition weak, fixing -flto.

### DIFF
--- a/libc-bottom-half/sources/__original_main.c
+++ b/libc-bottom-half/sources/__original_main.c
@@ -9,6 +9,7 @@ int main(int argc, char *argv[]);
 // If the user's `main` function expects arguments, the compiler won't emit
 // an `__original_main` function so this version will get linked in, which
 // initializes the argument data and calls `main`.
+__attribute__((weak))
 int __original_main(void) {
     __wasi_errno_t err;
 


### PR DESCRIPTION
Fixes https://github.com/CraneStation/wasi-libc/issues/137.