### PR TITLE
Fix environment variable init to exit successfully.

### DIFF
--- a/libc-bottom-half/sources/__environ.c
+++ b/libc-bottom-half/sources/__environ.c
@@ -59,6 +59,7 @@ static void __wasilibc_populate_environ(void) {
     }
 
     __environ = environ_ptrs;
+    return;
 oserr:
     _Exit(EX_OSERR);
 software:


### PR DESCRIPTION
This fixes https://github.com/bytecodealliance/wasmtime/issues/783.