### PR TITLE
Improvements to wasi-headers tool

### DIFF
--- a/tools/wasi-headers/Cargo.toml
+++ b/tools/wasi-headers/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasi-headers"
-version = "0.0.0"
-authors = ["Dan Gohman <sunfish@mozilla.com>"]
+version = "0.0.1"
+authors = ["Dan Gohman <sunfish@mozilla.com>", "Pat Hickey <phickey@fastly.com>"]
 license = "Apache-2.0"
 edition = "2018"
 publish = false
@@ -10,6 +10,7 @@ publish = false
 heck = "0.3.1"
 witx = { path = "WASI/tools/witx" }
 anyhow = "1.0.22"
+clap = "2.23"
 
 [dev-dependencies]
 diff = "0.1.11"

--- a/tools/wasi-headers/src/lib.rs
+++ b/tools/wasi-headers/src/lib.rs
@@ -2,17 +2,12 @@ mod c_header;
 
 use anyhow::{anyhow, Result};
 use c_header::to_c_header;
-use std::fs::read_dir;
+use std::fs;
 use std::io;
+use std::path::PathBuf;
 use witx::load;
 
-pub fn generate() -> Result<String> {
-    let mut inputs = read_dir("WASI/phases/snapshot/witx")?
-        .map(|res| res.map(|e| e.path()))
-        .collect::<Result<Vec<_>, io::Error>>()?;
-
-    inputs.sort();
-
+pub fn generate(inputs: &[PathBuf]) -> Result<String> {
     // TODO: drop the anyhow! part once witx switches to anyhow.
     let doc = load(&inputs).map_err(|e| anyhow!(e.to_string()))?;
 
@@ -23,4 +18,19 @@ pub fn generate() -> Result<String> {
         .join(", ");
 
     Ok(to_c_header(&doc, &inputs_str))
+}
+
+pub fn snapshot_witx_files() -> Result<Vec<PathBuf>> {
+    let snapshot_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("WASI/phases/snapshot/witx");
+    let mut inputs = fs::read_dir(snapshot_dir)?
+        .map(|res| res.map(|e| e.path()))
+        .collect::<Result<Vec<_>, io::Error>>()?;
+
+    inputs.sort();
+    Ok(inputs)
+}
+
+pub fn libc_wasi_api_header() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../libc-bottom-half/headers/public/wasi/api.h")
 }

--- a/tools/wasi-headers/src/main.rs
+++ b/tools/wasi-headers/src/main.rs
@@ -1,11 +1,60 @@
+#[macro_use]
+extern crate clap;
+
 use anyhow::Result;
+use clap::{Arg, SubCommand};
 use std::fs::File;
 use std::io::Write;
-use wasi_headers::generate;
+use std::path::PathBuf;
+use wasi_headers::{generate, libc_wasi_api_header, snapshot_witx_files};
 
-pub fn main() -> Result<()> {
-    let c_header = generate()?;
-    let mut file = File::create("../../libc-bottom-half/headers/public/wasi/api.h")?;
-    file.write_all(c_header.as_bytes())?;
+struct GenerateCommand {
+    /// Input witx file
+    inputs: Vec<PathBuf>,
+    /// Output header file
+    output: PathBuf,
+}
+
+impl GenerateCommand {
+    pub fn execute(&self) -> Result<()> {
+        let c_header = generate(&self.inputs)?;
+        let mut file = File::create(&self.output)?;
+        file.write_all(c_header.as_bytes())?;
+        Ok(())
+    }
+}
+
+fn main() -> Result<()> {
+    let matches = app_from_crate!()
+        .arg(Arg::with_name("inputs").required(true).multiple(true))
+        .arg(
+            Arg::with_name("output")
+                .short("o")
+                .long("output")
+                .takes_value(true)
+                .required(true),
+        )
+        .subcommand(
+            SubCommand::with_name("generate-libc")
+                .about("generate libc api.h from current snapshot"),
+        )
+        .get_matches();
+
+    let cmd = if matches.subcommand_matches("generate-libc").is_some() {
+        let inputs = snapshot_witx_files()?;
+        let output = libc_wasi_api_header();
+        GenerateCommand { inputs, output }
+    } else {
+        GenerateCommand {
+            inputs: matches
+                .values_of("inputs")
+                .expect("inputs required")
+                .map(PathBuf::from)
+                .collect(),
+            output: PathBuf::from(matches.value_of("output").expect("output required")),
+        }
+    };
+
+    cmd.execute()?;
     Ok(())
 }

--- a/tools/wasi-headers/tests/verify.rs
+++ b/tools/wasi-headers/tests/verify.rs
@@ -1,7 +1,11 @@
+use std::fs;
+
 #[test]
 fn assert_same_as_src() {
-    let actual = include_str!("../../../libc-bottom-half/headers/public/wasi/api.h");
-    let expected = wasi_headers::generate().expect("header generation should succeed");
+    let actual =
+        fs::read_to_string(wasi_headers::libc_wasi_api_header()).expect("read libc wasi/api.h");
+    let witx_files = wasi_headers::snapshot_witx_files().expect("parse snapshot witx files");
+    let expected = wasi_headers::generate(&witx_files).expect("header generation");
     if actual == expected {
         return;
     }
@@ -63,7 +67,9 @@ fn assert_same_as_src() {
     }
 
     eprintln!();
-    eprintln!("To regenerate the files, run `cd tools/wasi-headers && cargo run`.");
+    eprintln!(
+        "To regenerate the files, run `cd tools/wasi-headers && cargo run -- generate-libc`."
+    );
     eprintln!();
     panic!();
 }


### PR DESCRIPTION
Updates to the latest WASI submodule, handles changes to the witx ast, and restructures the lib/exe
to make the tool more flexible.

Adds support named pointer types as members of structs/unions. Throws an error for other unsupported cases like arrays, strings, or char8s as members of structs/unions.

Previous argument-free functionality works via the `generate-libc` subcommand, e.g. `cd tools/wasi-headers && cargo run -- generate-libc`.