### PR TITLE
Correct minor typo in c_headers.rs

### DIFF
--- a/libc-bottom-half/headers/public/wasi/api.h
+++ b/libc-bottom-half/headers/public/wasi/api.h
@@ -7,7 +7,7 @@
  * and defined values (macros).
  *
  * The interface described here is greatly inspired by [CloudABI]'s clean,
- * thoughtfully-designed, cabability-oriented, POSIX-style API.
+ * thoughtfully-designed, capability-oriented, POSIX-style API.
  *
  * [CloudABI]: https://github.com/NuxiNL/cloudlibc
  * [WASI]: https://github.com/WebAssembly/WASI/

--- a/tools/wasi-headers/src/c_header.rs
+++ b/tools/wasi-headers/src/c_header.rs
@@ -14,7 +14,7 @@ pub(crate) fn to_c_header(doc: &Document, inputs_str: &str) -> String {
  * and defined values (macros).
  *
  * The interface described here is greatly inspired by [CloudABI]'s clean,
- * thoughtfully-designed, cabability-oriented, POSIX-style API.
+ * thoughtfully-designed, capability-oriented, POSIX-style API.
  *
  * [CloudABI]: https://github.com/NuxiNL/cloudlibc
  * [WASI]: https://github.com/WebAssembly/WASI/


### PR DESCRIPTION
The header api.h was update using the following command:
```console
$ cd tools/wasi-headers
$ cargo run -- WASI/phases/snapshot/witx/typenames.witx \
  WASI/phases/snapshot/witx/wasi_snapshot_preview1.witx \
  --output ../../libc-bottom-half/headers/public/wasi/api.h
```